### PR TITLE
Only change incomingID for policies

### DIFF
--- a/internal/app/include_processor.go
+++ b/internal/app/include_processor.go
@@ -64,7 +64,7 @@ func excludedTag(value string, stripAnnotations bool) bool {
 
 func processIncludes(node *yaml.Node, loader policyLoader, stripAnnotations bool, incomingID string) (*yaml.Node, error) {
 	// Get the id for the currently being processed tree
-	if node.Kind == yaml.MappingNode {
+	if node.Kind == yaml.MappingNode && node.Tag == "!policy" {
 		for i := range node.Content {
 			if node.Content[i].Value == "id" {
 				r1 := regexp.MustCompile(`\W`)


### PR DESCRIPTION
If an object that has an anchor also has an id key, mt will
treat it like a policy and change the incomingID, but only when
processing anchors, not aliases. This leads to a mismatch in
anchors and aliases.

This commit ensures that incomingID is only changed when an object with
the !policy tag is encountered.

Related: conjurinc/ops#738