### PR TITLE
Rotate-Datakey: Add version as primary key

### DIFF
--- a/internal/app/model/v5/v5.go
+++ b/internal/app/model/v5/v5.go
@@ -11,14 +11,14 @@ type Credential struct {
 }
 
 type Secret struct {
-	Version    int
+	Version    int `gorm:"primaryKey;not null"`
 	Value      []byte
 	ResourceId string `gorm:"primaryKey;not null"`
 	ExpiresAt  time.Time
 }
 
 type SlosiloKeystore struct {
-	Id          string `gorm:"not null"`
+	Id          string `gorm:"primaryKey;not null"`
 	Key         []byte `gorm:"not null;type:bytea"`
 	Fingerprint string `gorm:"not null"`
 }

--- a/scripts/rotate-e2e.sh
+++ b/scripts/rotate-e2e.sh
@@ -49,6 +49,7 @@ deploy_conjur(){
   echo "✅ load test policy"
   docker compose exec client conjur list
   echo "✅ list objects"
+  docker compose exec client conjur variable set -i test/test -v firstvalue
   docker compose exec client conjur variable set -i test/test -v t3st
   echo "✅ set test value test/test = t3st"
   docker compose exec client conjur user  change-password  -p "${admin_password}"


### PR DESCRIPTION
Previously only ID was marked as primary key but that does not match the actual structure of the database and caused invalid update queries where more than one version of secret is stored.

Also adds multi version secret to test script.